### PR TITLE
Fix GCP image name construction to include project and registry path

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,6 +136,8 @@ try {
             let imageNameWithTag = `${cred.credentials.registry}/${choreoApp}:${process.env.NEW_SHA}`;
             if (cred.type === ECR) {
                 imageNameWithTag = `${cred.credentials.registry}/${organizationUuid}:${choreoApp}-${process.env.NEW_SHA}`;
+            } else if (cred.type === GCP) {
+                imageNameWithTag = `${cred.credentials.registry}/${cred.credentials.repository}/${choreoApp}:${process.env.NEW_SHA}`;
             }
             cluster_image_tags.push({
                 registry_id: cred.registry_id,


### PR DESCRIPTION
Add support for GCP Artifact Registry by including the repository path in the image name construction for GCP registry types.